### PR TITLE
fix:added exception and exception to catch missing run_id

### DIFF
--- a/conveyor/runtime/driver_logger.py
+++ b/conveyor/runtime/driver_logger.py
@@ -1,10 +1,10 @@
 import httpx
-from httpx import HTTPError, RequestError
+from httpx import HTTPStatusError, RequestError
 import time
 import logging
-from requests.exceptions import RequestException, HTTPError
 import json
 from nats.aio.client import Client as NATS
+from conveyor.runtime.exceptions import InvalidRunIDException
 
 
 class LokiClient:
@@ -24,12 +24,7 @@ class LokiClient:
         """
         log_entry = {
             "streams": [
-                {
-                    "stream": labels,
-                    "values": [
-                        [str(int(time.time() * 1e9)), message]
-                    ]
-                }
+                {"stream": labels, "values": [[str(int(time.time() * 1e9)), message]]}
             ]
         }
 
@@ -43,10 +38,10 @@ class LokiClient:
                 "Loki response status code: %s, response: %s, labels: %s",
                 response.status_code,
                 response.text,
-                labels
+                labels,
             )
 
-        except HTTPError as e:
+        except HTTPStatusError as e:
             status_code = getattr(e.response, "status_code", "N/A")
             reason = getattr(e.response, "reason_phrase", "N/A")
             text = getattr(e.response, "text", "N/A")
@@ -56,14 +51,14 @@ class LokiClient:
                 e,
                 reason,
                 text,
-                labels
+                labels,
             )
             raise
 
         except RequestError as e:
             logging.error("Failed to push log to Loki: %s | Labels: %s", e, labels)
             raise
-    
+
     # TODO: Close the LokiClient (httpx.AsyncClient) when the app is shutting down
     # This prevents socket leaks and ensures graceful shutdown.
     # Never close after every log — keep the client open for the app lifetime.
@@ -71,11 +66,11 @@ class LokiClient:
         await self.client.aclose()
 
 
-
-
 class DriverLogger:
 
-    def __init__(self, driver_name: str, labels: dict, nats_conn: NATS, loki_client: LokiClient):
+    def __init__(
+        self, driver_name: str, labels: dict, nats_conn: NATS, loki_client: LokiClient
+    ):
         """
         Initializes the DriverLogger with the driver name, labels, NATS connection, and Loki client.
         """
@@ -84,8 +79,7 @@ class DriverLogger:
         self.nats_conn = nats_conn
         self.loki_client = loki_client
 
-    async def log(self, labels: dict, message: str)->None:
-
+    async def log(self, labels: dict, message: str) -> None:
         """
         Merges the logger's labels with the provided labels and logs the message to the Loki client and NATS.
         :param labels: Additional labels to merge with the logger's labels.
@@ -94,23 +88,30 @@ class DriverLogger:
         :raises UnicodeEncodeError: If the message contains non-ASCII characters.
         """
 
-        merged_labels = {"driver": self.driver_name} 
-        merged_labels.update(self.labels)         
-        merged_labels.update(labels)                 
-        
-       
-        await self.loki_client.push_log(merged_labels,message)
+        merged_labels = {"driver": self.driver_name}
+        merged_labels.update(self.labels)
+        merged_labels.update(labels)
 
         run_id = merged_labels.get("run_id", "unknown_run")
 
+        if not run_id or not str(run_id).strip():
+            logging.error("Missing run_id from labels: %s", merged_labels)
+            raise InvalidRunIDException("Missing run_id from labels.")
+
+        await self.loki_client.push_log(merged_labels, message)
+
         timestamp = [str(int(time.time())), message]
-     
+
         logging.debug("encoding data to bytes for NATS : %s", timestamp)
         try:
             payload = json.dumps(timestamp).encode()
         except (TypeError, UnicodeEncodeError) as e:
-            logging.error("Failed to encode log payload for NATS: %s | Data: %s", e, timestamp)
+            logging.error(
+                "Failed to encode log payload for NATS: %s | Data: %s", e, timestamp
+            )
             raise
 
         logging.info("Publishing log to NATS: %s ", timestamp)
-        await self.nats_conn.publish(f"driver:{self.driver_name}:logs:{run_id}", payload)
+        await self.nats_conn.publish(
+            f"driver:{self.driver_name}:logs:{run_id}", payload
+        )

--- a/conveyor/runtime/exceptions.py
+++ b/conveyor/runtime/exceptions.py
@@ -1,0 +1,16 @@
+class DriverRuntimeException(Exception):
+    """
+    Base class for all exceptions raised by the Conveyor CI Driver Runtime.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+class InvalidRunIDException(DriverRuntimeException):
+    """Raised when the run_id is missing from the labels ."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message


### PR DESCRIPTION
Now validates that `run_id` is present and non-empty in merged labels
    - Raises `InvalidRunIDException` (subclass of `DriverRuntimeException`) if missing
    - Prevents malformed messages from being published to NATS